### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
         npm i 
         npm run build:ci
     - name: Publish project to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{secrets.SERVICE_IMAGE}}
         username: ${{secrets.DOCKER_LOGIN}}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore